### PR TITLE
docs: add roadmap document

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,18 @@
+# Roadmap
+
+## Short term
+
+- stabilize documentation and automation
+- improve setup and contributor onboarding
+
+## Mid term
+
+- refine content generation prompts
+- expand export and collaboration features
+- improve deployment and observability
+
+## Longer term
+
+- stronger analytics for creator workflows
+- richer multilingual publishing support
+- deeper automation with credible review gates


### PR DESCRIPTION
Closes #16

Adds a lightweight roadmap grouped by short-term, mid-term, and longer-term direction.