### PR TITLE
docs: add issue severity guide

### DIFF
--- a/docs/issue-severity.md
+++ b/docs/issue-severity.md
@@ -1,0 +1,13 @@
+# Issue Severity Guide
+
+## Low
+
+Small improvements, documentation work, or cleanup that does not block core user flows.
+
+## Medium
+
+Product or developer experience work that matters to reliability, onboarding, or maintainability.
+
+## High
+
+Security issues, broken production behavior, or failures in critical flows such as transcription, translation, or content generation.


### PR DESCRIPTION
Closes #17

Adds a simple definition of low, medium, and high issue severity for triage.