### PR TITLE
docs: add documentation index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,13 @@
+# Documentation Index
+
+- [Architecture](./architecture.md)
+- [Environment Setup](./environment-setup.md)
+- [Troubleshooting](./troubleshooting.md)
+- [Recording Best Practices](./recording-best-practices.md)
+- [Content Workflow](./content-workflow.md)
+- [Deployment](./deployment.md)
+- [Security](./security.md)
+- [Roadmap](./roadmap.md)
+- [Issue Severity](./issue-severity.md)
+- [Automation Operations](./automation-operations.md)
+- [Release Checklist](./release-checklist.md)


### PR DESCRIPTION
Closes #19

Adds a single entry point for the growing project documentation set.